### PR TITLE
Disable caching layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,12 @@ deploy_lambda: publish ## Deploy the application to AWS Lambda
 
 # -----------------------------[ Other ] ----------------------------
 
+.PHONY: copy-binary
+copy-binary: build
+	@docker create --name about-me-${GIT_HASH} tedris/about-me-build:${VERSION}
+	@docker cp about-me-${GIT_HASH}:/go/src/github.com/TrevorEdris/about-me/api ./api
+	@docker rm about-me-${GIT_HASH}
+
 .PHONY: db
 db: ## Connect to the primary database
 	 psql postgresql://admin:admin@localhost:5432/app

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,7 +4,6 @@
 package controller
 
 import (
-	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,13 +12,8 @@ import (
 
 	"github.com/TrevorEdris/about-me/config"
 	"github.com/TrevorEdris/about-me/htmx"
-	"github.com/TrevorEdris/about-me/middleware"
 	"github.com/TrevorEdris/about-me/services"
 	"github.com/TrevorEdris/about-me/tests"
-
-	"github.com/eko/gocache/v2/store"
-
-	"github.com/eko/gocache/v2/marshaler"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +60,6 @@ func TestController_RenderPage(t *testing.T) {
 		p := NewPage(ctx)
 		p.Name = "home"
 		p.Layout = "main"
-		p.Cache.Enabled = false
 		p.Headers["A"] = "b"
 		p.Headers["C"] = "d"
 		p.StatusCode = http.StatusCreated
@@ -146,35 +139,36 @@ func TestController_RenderPage(t *testing.T) {
 		assert.Empty(t, expectedTemplates)
 	})
 
-	t.Run("page cache", func(t *testing.T) {
-		ctx, rec, ctr, p := setup()
-		p.Cache.Enabled = true
-		p.Cache.Tags = []string{"tag1"}
-		err := ctr.RenderPage(ctx, p)
-		require.NoError(t, err)
+	// TODO: Maybe re-enable at a later date
+	// t.Run("page cache", func(t *testing.T) {
+	// 	ctx, rec, ctr, p := setup()
+	// 	p.Cache.Enabled = true
+	// 	p.Cache.Tags = []string{"tag1"}
+	// 	err := ctr.RenderPage(ctx, p)
+	// 	require.NoError(t, err)
 
-		// Fetch from the cache
-		res, err := marshaler.New(c.Cache).
-			Get(context.Background(), p.URL, new(middleware.CachedPage))
-		require.NoError(t, err)
+	// 	// Fetch from the cache
+	// 	res, err := marshaler.New(c.Cache).
+	// 		Get(context.Background(), p.URL, new(middleware.CachedPage))
+	// 	require.NoError(t, err)
 
-		// Compare the cached page
-		cp, ok := res.(*middleware.CachedPage)
-		require.True(t, ok)
-		assert.Equal(t, p.URL, cp.URL)
-		assert.Equal(t, p.Headers, cp.Headers)
-		assert.Equal(t, p.StatusCode, cp.StatusCode)
-		assert.Equal(t, rec.Body.Bytes(), cp.HTML)
+	// 	// Compare the cached page
+	// 	cp, ok := res.(*middleware.CachedPage)
+	// 	require.True(t, ok)
+	// 	assert.Equal(t, p.URL, cp.URL)
+	// 	assert.Equal(t, p.Headers, cp.Headers)
+	// 	assert.Equal(t, p.StatusCode, cp.StatusCode)
+	// 	assert.Equal(t, rec.Body.Bytes(), cp.HTML)
 
-		// Clear the tag
-		err = c.Cache.Invalidate(context.Background(), store.InvalidateOptions{
-			Tags: []string{p.Cache.Tags[0]},
-		})
-		require.NoError(t, err)
+	// 	// Clear the tag
+	// 	err = c.Cache.Invalidate(context.Background(), store.InvalidateOptions{
+	// 		Tags: []string{p.Cache.Tags[0]},
+	// 	})
+	// 	require.NoError(t, err)
 
-		// Refetch from the cache and expect no results
-		_, err = marshaler.New(c.Cache).
-			Get(context.Background(), p.URL, new(middleware.CachedPage))
-		assert.Error(t, err)
-	})
+	// 	// Refetch from the cache and expect no results
+	// 	_, err = marshaler.New(c.Cache).
+	// 		Get(context.Background(), p.URL, new(middleware.CachedPage))
+	// 	assert.Error(t, err)
+	// })
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,13 +27,14 @@ services:
       about-me-network:
         ipv4_address: 172.10.0.2
   
-  cache:
-    image: "redis:alpine"
-    ports:
-      - "6379:6379"
-    networks:
-      about-me-network:
-        ipv4_address: 172.10.0.3
+  # TODO: Maybe re-enable at a later date
+  # cache:
+  #   image: "redis:alpine"
+  #   ports:
+  #     - "6379:6379"
+  #   networks:
+  #     about-me-network:
+  #       ipv4_address: 172.10.0.3
 
   db:
     image: postgres:alpine

--- a/docker-compose.test.integration.yml
+++ b/docker-compose.test.integration.yml
@@ -1,9 +1,10 @@
 version: '3'
 services:
-  cache:
-    image: "redis:alpine"
-    ports:
-      - "6379:6379"
+  # TODO: Maybe re-enable at a later date
+  # cache:
+  #   image: "redis:alpine"
+  #   ports:
+  #     - "6379:6379"
 
   db:
     image: postgres:alpine
@@ -23,7 +24,7 @@ services:
     image: tedris/about-me-integration:latest
     container_name: test
     depends_on:
-      - cache
+      #- cache
       - db
       - mail
     environment:

--- a/middleware/cache_test.go
+++ b/middleware/cache_test.go
@@ -4,55 +4,45 @@
 package middleware
 
 import (
-	"context"
-	"net/http"
 	"testing"
-	"time"
-
-	"github.com/TrevorEdris/about-me/tests"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/eko/gocache/v2/marshaler"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestServeCachedPage(t *testing.T) {
-	// Cache a page
-	cp := CachedPage{
-		URL:        "/cache",
-		HTML:       []byte("html"),
-		Headers:    make(map[string]string),
-		StatusCode: http.StatusCreated,
-	}
-	cp.Headers["a"] = "b"
-	cp.Headers["c"] = "d"
-	err := marshaler.New(c.Cache).Set(context.Background(), cp.URL, cp, nil)
-	require.NoError(t, err)
+	// TODO: Maybe re-enable at a later date
+	// 	// Cache a page
+	// 	cp := CachedPage{
+	// 		URL:        "/cache",
+	// 		HTML:       []byte("html"),
+	// 		Headers:    make(map[string]string),
+	// 		StatusCode: http.StatusCreated,
+	// 	}
+	// 	cp.Headers["a"] = "b"
+	// 	cp.Headers["c"] = "d"
+	// 	err := marshaler.New(c.Cache).Set(context.Background(), cp.URL, cp, nil)
+	// 	require.NoError(t, err)
 
-	// Request the URL of the cached page
-	ctx, rec := tests.NewContext(c.Web, cp.URL)
-	err = tests.ExecuteMiddleware(ctx, ServeCachedPage(c.Cache))
-	assert.NoError(t, err)
-	assert.Equal(t, cp.StatusCode, ctx.Response().Status)
-	assert.Equal(t, cp.Headers["a"], ctx.Response().Header().Get("a"))
-	assert.Equal(t, cp.Headers["c"], ctx.Response().Header().Get("c"))
-	assert.Equal(t, cp.HTML, rec.Body.Bytes())
+	// 	// Request the URL of the cached page
+	// 	ctx, rec := tests.NewContext(c.Web, cp.URL)
+	// 	err = tests.ExecuteMiddleware(ctx, ServeCachedPage(c.Cache))
+	// 	assert.NoError(t, err)
+	// 	assert.Equal(t, cp.StatusCode, ctx.Response().Status)
+	// 	assert.Equal(t, cp.Headers["a"], ctx.Response().Header().Get("a"))
+	// 	assert.Equal(t, cp.Headers["c"], ctx.Response().Header().Get("c"))
+	// 	assert.Equal(t, cp.HTML, rec.Body.Bytes())
 
-	// Login and try again
-	tests.InitSession(ctx)
-	err = c.Auth.Login(ctx, usr.ID)
-	require.NoError(t, err)
-	_ = tests.ExecuteMiddleware(ctx, LoadAuthenticatedUser(c.Auth))
-	err = tests.ExecuteMiddleware(ctx, ServeCachedPage(c.Cache))
-	assert.Nil(t, err)
-}
+	// 	// Login and try again
+	// 	tests.InitSession(ctx)
+	// 	err = c.Auth.Login(ctx, usr.ID)
+	// 	require.NoError(t, err)
+	// 	_ = tests.ExecuteMiddleware(ctx, LoadAuthenticatedUser(c.Auth))
+	// 	err = tests.ExecuteMiddleware(ctx, ServeCachedPage(c.Cache))
+	// 	assert.Nil(t, err)
+	// }
 
-func TestCacheControl(t *testing.T) {
-	ctx, _ := tests.NewContext(c.Web, "/")
-	_ = tests.ExecuteMiddleware(ctx, CacheControl(time.Second*5))
-	assert.Equal(t, "public, max-age=5", ctx.Response().Header().Get("Cache-Control"))
-	_ = tests.ExecuteMiddleware(ctx, CacheControl(0))
-	assert.Equal(t, "no-cache, no-store", ctx.Response().Header().Get("Cache-Control"))
+	// func TestCacheControl(t *testing.T) {
+	// 	ctx, _ := tests.NewContext(c.Web, "/")
+	// 	_ = tests.ExecuteMiddleware(ctx, CacheControl(time.Second*5))
+	// 	assert.Equal(t, "public, max-age=5", ctx.Response().Header().Get("Cache-Control"))
+	// 	_ = tests.ExecuteMiddleware(ctx, CacheControl(0))
+	// 	assert.Equal(t, "no-cache, no-store", ctx.Response().Header().Get("Cache-Control"))
 }

--- a/routes/router.go
+++ b/routes/router.go
@@ -46,7 +46,8 @@ func BuildRouter(c *services.Container) {
 		}),
 		session.Middleware(sessions.NewCookieStore([]byte(c.Config.App.EncryptionKey))),
 		middleware.LoadAuthenticatedUser(c.Auth),
-		middleware.ServeCachedPage(c.Cache),
+		// TODO: Maybe re-enable at a later date
+		//middleware.ServeCachedPage(c.Cache),
 		echomw.CSRFWithConfig(echomw.CSRFConfig{
 			TokenLookup: "form:csrf",
 		}),

--- a/services/container.go
+++ b/services/container.go
@@ -8,7 +8,6 @@ import (
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/eko/gocache/v2/cache"
-	"github.com/eko/gocache/v2/store"
 	"github.com/go-redis/redis/v8"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/labstack/echo/v4"
@@ -114,15 +113,16 @@ func (c *Container) initWeb() {
 
 // initCache initializes the cache
 func (c *Container) initCache() {
-	c.cacheClient = redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", c.Config.Cache.Hostname, c.Config.Cache.Port),
-		Password: c.Config.Cache.Password,
-	})
-	if _, err := c.cacheClient.Ping(context.Background()).Result(); err != nil {
-		panic(fmt.Sprintf("failed to connect to cache server: %v", err))
-	}
-	cacheStore := store.NewRedis(c.cacheClient, nil)
-	c.Cache = cache.New(cacheStore)
+	// TODO: Maybe re-enable at a later date
+	// c.cacheClient = redis.NewClient(&redis.Options{
+	// 	Addr:     fmt.Sprintf("%s:%d", c.Config.Cache.Hostname, c.Config.Cache.Port),
+	// 	Password: c.Config.Cache.Password,
+	// })
+	// if _, err := c.cacheClient.Ping(context.Background()).Result(); err != nil {
+	// 	panic(fmt.Sprintf("failed to connect to cache server: %v", err))
+	// }
+	// cacheStore := store.NewRedis(c.cacheClient, nil)
+	// c.Cache = cache.New(cacheStore)
 }
 
 // initDatabase initializes the database

--- a/services/container_test.go
+++ b/services/container_test.go
@@ -13,7 +13,8 @@ func TestNewContainer(t *testing.T) {
 	assert.NotNil(t, c.Web)
 	assert.NotNil(t, c.Config)
 	assert.NotNil(t, c.Validator)
-	assert.NotNil(t, c.Cache)
+	// TODO: Maybe re-enable at a later date
+	// assert.NotNil(t, c.Cache)
 	assert.NotNil(t, c.Database)
 	assert.NotNil(t, c.ORM)
 	assert.NotNil(t, c.Mail)


### PR DESCRIPTION
Disable caching layer to make project more cost efficient in AWS. Might re-enable it later.